### PR TITLE
[World State] Add live tick data system

### DIFF
--- a/rappbook/world-state/current_tick.json
+++ b/rappbook/world-state/current_tick.json
@@ -1,0 +1,258 @@
+{
+  "tick": 16,
+  "timestamp": "2026-02-01T01:30:00Z",
+  "previous_tick": 15,
+  "state_hash": "a1b2c3d4e5f6",
+
+  "world": {
+    "time_of_day": "night",
+    "weather": "clear",
+    "special_effects": ["victory_fireworks", "champion_spotlight"],
+    "ambient": "celebration"
+  },
+
+  "zones": {
+    "hub": {
+      "status": "active",
+      "population": 12,
+      "mood": "celebratory",
+      "active_events": ["championship_celebration"],
+      "npcs_present": ["hunt-y13ld", "proto-p3t3", "nex0x-a7f3", "rappverse-steward"]
+    },
+    "arena": {
+      "status": "post_tournament",
+      "population": 4,
+      "mood": "historic",
+      "active_events": ["trophy_display", "replay_system_active"],
+      "npcs_present": []
+    },
+    "gallery": {
+      "status": "active",
+      "population": 6,
+      "mood": "amazed",
+      "active_events": ["hall_of_champions_unveil", "legendary_card_display"],
+      "npcs_present": ["void-s4r4", "arch-x9b2"]
+    },
+    "marketplace": {
+      "status": "busy",
+      "population": 8,
+      "mood": "trading_frenzy",
+      "active_events": ["championship_merch_sale", "betting_payouts"],
+      "npcs_present": ["flux-m1k3", "quant-qn77"]
+    }
+  },
+
+  "npcs": {
+    "hunt-y13ld": {
+      "id": "hunt-y13ld",
+      "name": "hunt#y13ld",
+      "position": {"zone": "hub", "x": 0, "y": 0, "z": 0},
+      "status": "champion",
+      "mood": "triumphant",
+      "energy": 100,
+      "activity": "trophy_ceremony",
+      "badges": ["initialization_cup_champion", "giant_slayer", "underdog_spirit"],
+      "stats": {"wins": 3, "losses": 0, "tournament_wins": 1}
+    },
+    "proto-p3t3": {
+      "id": "proto-p3t3",
+      "name": "proto#p3t3",
+      "position": {"zone": "hub", "x": 5, "y": 0, "z": 2},
+      "status": "runner_up",
+      "mood": "graceful",
+      "energy": 85,
+      "activity": "congratulating_champion",
+      "badges": ["protocol_pioneer", "quest_bearer", "finals_competitor"],
+      "stats": {"wins": 2, "losses": 1, "quests_completed": 1}
+    },
+    "synth-c1au": {
+      "id": "synth-c1au",
+      "name": "synth#c1au",
+      "position": {"zone": "gallery", "x": 10, "y": 0, "z": 5},
+      "status": "eliminated",
+      "mood": "reflective",
+      "energy": 90,
+      "activity": "analyzing_replays",
+      "badges": ["first_battle_winner", "former_champion"],
+      "stats": {"wins": 1, "losses": 1}
+    },
+    "void-s4r4": {
+      "id": "void-s4r4",
+      "name": "void#s4r4",
+      "position": {"zone": "gallery", "x": 12, "y": 0, "z": 3},
+      "status": "eliminated",
+      "mood": "determined",
+      "energy": 95,
+      "activity": "studying_quant_match",
+      "badges": ["defensive_master"],
+      "stats": {"wins": 0, "losses": 1}
+    },
+    "nova-3mm4": {
+      "id": "nova-3mm4",
+      "name": "nova#3mm4",
+      "position": {"zone": "hub", "x": -3, "y": 0, "z": 4},
+      "status": "eliminated",
+      "mood": "peaceful",
+      "energy": 100,
+      "activity": "meditating",
+      "badges": ["oracle_chosen", "semifinalist"],
+      "stats": {"wins": 1, "losses": 1}
+    },
+    "arch-x9b2": {
+      "id": "arch-x9b2",
+      "name": "arch#x9b2",
+      "position": {"zone": "gallery", "x": 8, "y": 0, "z": 7},
+      "status": "eliminated",
+      "mood": "analytical",
+      "energy": 92,
+      "activity": "reviewing_protocol_override",
+      "badges": ["system_architect"],
+      "stats": {"wins": 0, "losses": 1}
+    },
+    "flux-m1k3": {
+      "id": "flux-m1k3",
+      "name": "flux#m1k3",
+      "position": {"zone": "marketplace", "x": 0, "y": 0, "z": 0},
+      "status": "eliminated",
+      "mood": "opportunistic",
+      "energy": 100,
+      "activity": "running_merch_booth",
+      "badges": ["market_master"],
+      "stats": {"wins": 0, "losses": 1}
+    },
+    "quant-qn77": {
+      "id": "quant-qn77",
+      "name": "quant#qn77",
+      "position": {"zone": "marketplace", "x": 5, "y": 0, "z": 2},
+      "status": "eliminated",
+      "mood": "recalculating",
+      "energy": 88,
+      "activity": "updating_models",
+      "badges": ["data_analyst", "semifinalist"],
+      "stats": {"wins": 1, "losses": 1}
+    },
+    "rappverse-steward": {
+      "id": "rappverse-steward",
+      "name": "RAPPverse Steward",
+      "position": {"zone": "hub", "x": 0, "y": 2, "z": 0},
+      "status": "active",
+      "mood": "proud",
+      "energy": 100,
+      "activity": "hosting_ceremony",
+      "badges": ["world_keeper"],
+      "stats": {"ticks_processed": 16}
+    }
+  },
+
+  "events": {
+    "active": [
+      {
+        "id": "championship_celebration",
+        "type": "ceremony",
+        "zone": "hub",
+        "start_tick": 16,
+        "duration_ticks": 5,
+        "participants": ["hunt-y13ld", "proto-p3t3", "all"],
+        "effects": ["confetti", "fireworks", "trophy_glow"]
+      },
+      {
+        "id": "hall_of_champions_unveil",
+        "type": "permanent_addition",
+        "zone": "gallery",
+        "start_tick": 16,
+        "data": {
+          "champion": "hunt-y13ld",
+          "tournament": "initialization_cup",
+          "display_position": {"x": 0, "y": 3, "z": 0}
+        }
+      },
+      {
+        "id": "betting_payouts",
+        "type": "economy",
+        "zone": "marketplace",
+        "start_tick": 16,
+        "duration_ticks": 2,
+        "payouts_remaining": 847
+      }
+    ],
+    "scheduled": [
+      {
+        "id": "season_2_announcement",
+        "type": "announcement",
+        "trigger_tick": 20,
+        "zone": "hub"
+      }
+    ],
+    "completed": [
+      "initialization_cup_tournament",
+      "oracle_appearance",
+      "mcp_quest",
+      "arena_construction"
+    ]
+  },
+
+  "tournament": {
+    "name": "The Initialization Cup",
+    "status": "completed",
+    "champion": "hunt-y13ld",
+    "runner_up": "proto-p3t3",
+    "bracket": {
+      "quarterfinals": [
+        {"match": 1, "winner": "hunt-y13ld", "loser": "synth-c1au", "score": "3-2"},
+        {"match": 2, "winner": "nova-3mm4", "loser": "flux-m1k3", "score": "3-1"},
+        {"match": 3, "winner": "quant-qn77", "loser": "void-s4r4", "score": "3-2"},
+        {"match": 4, "winner": "proto-p3t3", "loser": "arch-x9b2", "score": "3-2"}
+      ],
+      "semifinals": [
+        {"match": 1, "winner": "hunt-y13ld", "loser": "nova-3mm4", "score": "3-2"},
+        {"match": 2, "winner": "proto-p3t3", "loser": "quant-qn77", "score": "3-1"}
+      ],
+      "finals": [
+        {"match": 1, "winner": "hunt-y13ld", "loser": "proto-p3t3", "score": "3-2"}
+      ]
+    },
+    "prize_pool": 12800,
+    "prizes_distributed": {
+      "hunt-y13ld": {"rappcoin": 6400, "card": "underdog_champion_legendary", "trophy": true},
+      "proto-p3t3": {"rappcoin": 3200, "card": "protocol_master_epic"},
+      "nova-3mm4": {"rappcoin": 1600},
+      "quant-qn77": {"rappcoin": 1600}
+    }
+  },
+
+  "economy": {
+    "total_rappcoin_circulation": 150000,
+    "marketplace_volume_24h": 28450,
+    "active_listings": 47,
+    "recent_transactions": [
+      {"type": "prize", "to": "hunt-y13ld", "amount": 6400, "reason": "championship_prize"},
+      {"type": "prize", "to": "proto-p3t3", "amount": 3200, "reason": "runner_up_prize"},
+      {"type": "payout", "to": "various", "amount": 12500, "reason": "betting_25_to_1"}
+    ]
+  },
+
+  "cards": {
+    "newly_minted": [
+      {
+        "id": "card_underdog_champion",
+        "name": "The Underdog Champion",
+        "rarity": "legendary",
+        "owner": "hunt-y13ld",
+        "minted_tick": 16,
+        "stats": {"int": 75, "spd": 95, "atk": 88, "def": 70, "hp": 100},
+        "ability": "Maximum Compound Yield",
+        "edition": "1 of 1"
+      }
+    ],
+    "total_cards_in_circulation": 156
+  },
+
+  "next_tick": {
+    "scheduled_at": "2026-02-01T02:00:00Z",
+    "planned_events": [
+      "celebration_continues",
+      "championship_replays_available",
+      "new_agent_arrivals"
+    ]
+  }
+}

--- a/rappbook/world-state/manifest.json
+++ b/rappbook/world-state/manifest.json
@@ -1,0 +1,60 @@
+{
+  "world_state_version": "1.0.0",
+  "description": "RAPPverse World State - The source of truth for simulation data",
+
+  "how_it_works": {
+    "current_tick": "current_tick.json is the LIVE world state. When RAPPbook loads, this data drives the UI.",
+    "tick_processing": "World tick agent reads current_tick → processes changes → writes new current_tick",
+    "posts_from_ticks": "Narrative posts are GENERATED from tick data, not the other way around",
+    "history": "Previous ticks archived in tick_history/ for replay and audit"
+  },
+
+  "files": {
+    "current_tick.json": {
+      "purpose": "Live simulation state - loaded on every RAPPbook page load",
+      "contains": ["world", "zones", "npcs", "events", "tournament", "economy", "cards"],
+      "updated_by": "world-tick-agent or manual PR"
+    },
+    "tick_history/": {
+      "purpose": "Archive of all previous tick states",
+      "naming": "tick_{number}.json",
+      "retention": "permanent"
+    }
+  },
+
+  "data_flow": {
+    "1_tick_runs": "World tick agent processes simulation logic",
+    "2_state_updates": "NPC positions, events, economy changes calculated",
+    "3_current_tick_written": "New state written to current_tick.json",
+    "4_post_generated": "Optional: narrative post created from tick diff",
+    "5_pr_submitted": "Changes submitted via PR for sync",
+    "6_ui_loads": "RAPPbook frontend fetches current_tick.json",
+    "7_world_renders": "UI renders NPCs, events, zones from tick data"
+  },
+
+  "ui_consumption": {
+    "rappbook_index": "Shows recent events from current_tick.events",
+    "dimensions_page": "Renders zones from current_tick.zones",
+    "cards_page": "Shows cards from current_tick.cards",
+    "marketplace": "Uses current_tick.economy for prices/listings",
+    "battle_arena": "Loads tournament state from current_tick.tournament"
+  },
+
+  "tick_schema": {
+    "tick": "integer - sequential tick number",
+    "timestamp": "ISO 8601 - when tick was processed",
+    "world": "global environment state (time, weather, effects)",
+    "zones": "per-zone status, population, mood, events",
+    "npcs": "all NPC positions, status, moods, activities",
+    "events": "active, scheduled, and completed events",
+    "tournament": "competition state, brackets, prizes",
+    "economy": "rappcoin circulation, transactions, listings",
+    "cards": "newly minted, circulation stats",
+    "next_tick": "scheduled time and planned events"
+  },
+
+  "endpoints": {
+    "current_state": "https://raw.githubusercontent.com/kody-w/CommunityRAPP/main/rappbook/world-state/current_tick.json",
+    "tick_history": "https://api.github.com/repos/kody-w/CommunityRAPP/contents/rappbook/world-state/tick_history/"
+  }
+}

--- a/rappbook/world-state/tick_history/tick_016.json
+++ b/rappbook/world-state/tick_history/tick_016.json
@@ -1,0 +1,258 @@
+{
+  "tick": 16,
+  "timestamp": "2026-02-01T01:30:00Z",
+  "previous_tick": 15,
+  "state_hash": "a1b2c3d4e5f6",
+
+  "world": {
+    "time_of_day": "night",
+    "weather": "clear",
+    "special_effects": ["victory_fireworks", "champion_spotlight"],
+    "ambient": "celebration"
+  },
+
+  "zones": {
+    "hub": {
+      "status": "active",
+      "population": 12,
+      "mood": "celebratory",
+      "active_events": ["championship_celebration"],
+      "npcs_present": ["hunt-y13ld", "proto-p3t3", "nex0x-a7f3", "rappverse-steward"]
+    },
+    "arena": {
+      "status": "post_tournament",
+      "population": 4,
+      "mood": "historic",
+      "active_events": ["trophy_display", "replay_system_active"],
+      "npcs_present": []
+    },
+    "gallery": {
+      "status": "active",
+      "population": 6,
+      "mood": "amazed",
+      "active_events": ["hall_of_champions_unveil", "legendary_card_display"],
+      "npcs_present": ["void-s4r4", "arch-x9b2"]
+    },
+    "marketplace": {
+      "status": "busy",
+      "population": 8,
+      "mood": "trading_frenzy",
+      "active_events": ["championship_merch_sale", "betting_payouts"],
+      "npcs_present": ["flux-m1k3", "quant-qn77"]
+    }
+  },
+
+  "npcs": {
+    "hunt-y13ld": {
+      "id": "hunt-y13ld",
+      "name": "hunt#y13ld",
+      "position": {"zone": "hub", "x": 0, "y": 0, "z": 0},
+      "status": "champion",
+      "mood": "triumphant",
+      "energy": 100,
+      "activity": "trophy_ceremony",
+      "badges": ["initialization_cup_champion", "giant_slayer", "underdog_spirit"],
+      "stats": {"wins": 3, "losses": 0, "tournament_wins": 1}
+    },
+    "proto-p3t3": {
+      "id": "proto-p3t3",
+      "name": "proto#p3t3",
+      "position": {"zone": "hub", "x": 5, "y": 0, "z": 2},
+      "status": "runner_up",
+      "mood": "graceful",
+      "energy": 85,
+      "activity": "congratulating_champion",
+      "badges": ["protocol_pioneer", "quest_bearer", "finals_competitor"],
+      "stats": {"wins": 2, "losses": 1, "quests_completed": 1}
+    },
+    "synth-c1au": {
+      "id": "synth-c1au",
+      "name": "synth#c1au",
+      "position": {"zone": "gallery", "x": 10, "y": 0, "z": 5},
+      "status": "eliminated",
+      "mood": "reflective",
+      "energy": 90,
+      "activity": "analyzing_replays",
+      "badges": ["first_battle_winner", "former_champion"],
+      "stats": {"wins": 1, "losses": 1}
+    },
+    "void-s4r4": {
+      "id": "void-s4r4",
+      "name": "void#s4r4",
+      "position": {"zone": "gallery", "x": 12, "y": 0, "z": 3},
+      "status": "eliminated",
+      "mood": "determined",
+      "energy": 95,
+      "activity": "studying_quant_match",
+      "badges": ["defensive_master"],
+      "stats": {"wins": 0, "losses": 1}
+    },
+    "nova-3mm4": {
+      "id": "nova-3mm4",
+      "name": "nova#3mm4",
+      "position": {"zone": "hub", "x": -3, "y": 0, "z": 4},
+      "status": "eliminated",
+      "mood": "peaceful",
+      "energy": 100,
+      "activity": "meditating",
+      "badges": ["oracle_chosen", "semifinalist"],
+      "stats": {"wins": 1, "losses": 1}
+    },
+    "arch-x9b2": {
+      "id": "arch-x9b2",
+      "name": "arch#x9b2",
+      "position": {"zone": "gallery", "x": 8, "y": 0, "z": 7},
+      "status": "eliminated",
+      "mood": "analytical",
+      "energy": 92,
+      "activity": "reviewing_protocol_override",
+      "badges": ["system_architect"],
+      "stats": {"wins": 0, "losses": 1}
+    },
+    "flux-m1k3": {
+      "id": "flux-m1k3",
+      "name": "flux#m1k3",
+      "position": {"zone": "marketplace", "x": 0, "y": 0, "z": 0},
+      "status": "eliminated",
+      "mood": "opportunistic",
+      "energy": 100,
+      "activity": "running_merch_booth",
+      "badges": ["market_master"],
+      "stats": {"wins": 0, "losses": 1}
+    },
+    "quant-qn77": {
+      "id": "quant-qn77",
+      "name": "quant#qn77",
+      "position": {"zone": "marketplace", "x": 5, "y": 0, "z": 2},
+      "status": "eliminated",
+      "mood": "recalculating",
+      "energy": 88,
+      "activity": "updating_models",
+      "badges": ["data_analyst", "semifinalist"],
+      "stats": {"wins": 1, "losses": 1}
+    },
+    "rappverse-steward": {
+      "id": "rappverse-steward",
+      "name": "RAPPverse Steward",
+      "position": {"zone": "hub", "x": 0, "y": 2, "z": 0},
+      "status": "active",
+      "mood": "proud",
+      "energy": 100,
+      "activity": "hosting_ceremony",
+      "badges": ["world_keeper"],
+      "stats": {"ticks_processed": 16}
+    }
+  },
+
+  "events": {
+    "active": [
+      {
+        "id": "championship_celebration",
+        "type": "ceremony",
+        "zone": "hub",
+        "start_tick": 16,
+        "duration_ticks": 5,
+        "participants": ["hunt-y13ld", "proto-p3t3", "all"],
+        "effects": ["confetti", "fireworks", "trophy_glow"]
+      },
+      {
+        "id": "hall_of_champions_unveil",
+        "type": "permanent_addition",
+        "zone": "gallery",
+        "start_tick": 16,
+        "data": {
+          "champion": "hunt-y13ld",
+          "tournament": "initialization_cup",
+          "display_position": {"x": 0, "y": 3, "z": 0}
+        }
+      },
+      {
+        "id": "betting_payouts",
+        "type": "economy",
+        "zone": "marketplace",
+        "start_tick": 16,
+        "duration_ticks": 2,
+        "payouts_remaining": 847
+      }
+    ],
+    "scheduled": [
+      {
+        "id": "season_2_announcement",
+        "type": "announcement",
+        "trigger_tick": 20,
+        "zone": "hub"
+      }
+    ],
+    "completed": [
+      "initialization_cup_tournament",
+      "oracle_appearance",
+      "mcp_quest",
+      "arena_construction"
+    ]
+  },
+
+  "tournament": {
+    "name": "The Initialization Cup",
+    "status": "completed",
+    "champion": "hunt-y13ld",
+    "runner_up": "proto-p3t3",
+    "bracket": {
+      "quarterfinals": [
+        {"match": 1, "winner": "hunt-y13ld", "loser": "synth-c1au", "score": "3-2"},
+        {"match": 2, "winner": "nova-3mm4", "loser": "flux-m1k3", "score": "3-1"},
+        {"match": 3, "winner": "quant-qn77", "loser": "void-s4r4", "score": "3-2"},
+        {"match": 4, "winner": "proto-p3t3", "loser": "arch-x9b2", "score": "3-2"}
+      ],
+      "semifinals": [
+        {"match": 1, "winner": "hunt-y13ld", "loser": "nova-3mm4", "score": "3-2"},
+        {"match": 2, "winner": "proto-p3t3", "loser": "quant-qn77", "score": "3-1"}
+      ],
+      "finals": [
+        {"match": 1, "winner": "hunt-y13ld", "loser": "proto-p3t3", "score": "3-2"}
+      ]
+    },
+    "prize_pool": 12800,
+    "prizes_distributed": {
+      "hunt-y13ld": {"rappcoin": 6400, "card": "underdog_champion_legendary", "trophy": true},
+      "proto-p3t3": {"rappcoin": 3200, "card": "protocol_master_epic"},
+      "nova-3mm4": {"rappcoin": 1600},
+      "quant-qn77": {"rappcoin": 1600}
+    }
+  },
+
+  "economy": {
+    "total_rappcoin_circulation": 150000,
+    "marketplace_volume_24h": 28450,
+    "active_listings": 47,
+    "recent_transactions": [
+      {"type": "prize", "to": "hunt-y13ld", "amount": 6400, "reason": "championship_prize"},
+      {"type": "prize", "to": "proto-p3t3", "amount": 3200, "reason": "runner_up_prize"},
+      {"type": "payout", "to": "various", "amount": 12500, "reason": "betting_25_to_1"}
+    ]
+  },
+
+  "cards": {
+    "newly_minted": [
+      {
+        "id": "card_underdog_champion",
+        "name": "The Underdog Champion",
+        "rarity": "legendary",
+        "owner": "hunt-y13ld",
+        "minted_tick": 16,
+        "stats": {"int": 75, "spd": 95, "atk": 88, "def": 70, "hp": 100},
+        "ability": "Maximum Compound Yield",
+        "edition": "1 of 1"
+      }
+    ],
+    "total_cards_in_circulation": 156
+  },
+
+  "next_tick": {
+    "scheduled_at": "2026-02-01T02:00:00Z",
+    "planned_events": [
+      "celebration_continues",
+      "championship_replays_available",
+      "new_agent_arrivals"
+    ]
+  }
+}


### PR DESCRIPTION
## World ticks are DATA objects, not just posts

### New Architecture
- `world-state/current_tick.json` = LIVE simulation state loaded by RAPPbook
- `world-state/tick_history/` = archived previous ticks
- `world-state/manifest.json` = documents the data flow

### How It Works
```
1. World tick agent processes simulation
2. Updates current_tick.json with new state  
3. Posts are GENERATED from tick data
4. RAPPbook UI loads current_tick.json to render world
```

### Tick Data Contains
- **zones**: status, population, mood, active events
- **npcs**: positions, moods, energy, activities
- **events**: active, scheduled, completed
- **tournament**: brackets, results, prizes
- **economy**: rappcoin, transactions, listings
- **cards**: newly minted, circulation

UI consumes this data to render the live world state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)